### PR TITLE
Fix unused variable warning when only using variable in test name

### DIFF
--- a/lib/checkov.ex
+++ b/lib/checkov.ex
@@ -111,10 +111,10 @@ defmodule Checkov do
   defp create_test(name, binding, test_block, context) do
     quoted_variables =
       Enum.map(binding, fn {variable_name, variable_value} ->
-        {:=, [],
+        {:__block__, [],
          [
-           {:var!, [context: Elixir, import: Kernel], [{variable_name, [], Elixir}]},
-           variable_value
+           {:=, [], [{:var!, [context: Elixir, import: Kernel], [{variable_name, [], Elixir}]}, variable_value]},
+           {:=, [], [{:_, [], Elixir}, {:var!, [context: Elixir, import: Kernel], [{variable_name, [], Elixir}]}]}
          ]}
       end)
 

--- a/test/checkov_test.exs
+++ b/test/checkov_test.exs
@@ -62,5 +62,14 @@ defmodule CheckovTest do
     ]
   end
 
+  data_test "#{name}" do
+    assert true
+
+    where [
+      [:name],
+      ["no unused variable warning"]
+    ]
+  end
+
   defp stuff(x), do: x + 1
 end


### PR DESCRIPTION
Given a test like this:

```elixir
data_test "#{description}" do
  assert x

  where [
    [:description, :x],
    ["pass", true],
    ["fail", false]
  ]
end
```

You would get a compiler warning for unused variable `description`, since it's not used in the test body. 

This PR will fix that.